### PR TITLE
Test xgboost vs logistic regression performance in pyspark

### DIFF
--- a/geolifeclef/utils.py
+++ b/geolifeclef/utils.py
@@ -19,14 +19,13 @@ def get_spark(
     """Get a spark session for a single driver."""
     builder = (
         SparkSession.builder.config("spark.driver.memory", memory)
-        .config("spark.driver.cores", cores)
         .config("spark.sql.execution.arrow.pyspark.enabled", "true")
         .config("spark.driver.maxResultSize", "4g")
         .config("spark.local.dir", f"{local_dir}/{int(time.time())}")
     )
     for k, v in kwargs.items():
         builder = builder.config(k, v)
-    return builder.appName(app_name).getOrCreate()
+    return builder.appName(app_name).master(f"local[{cores}]").getOrCreate()
 
 
 @contextmanager

--- a/geolifeclef/workflows/benchmark_classification.py
+++ b/geolifeclef/workflows/benchmark_classification.py
@@ -1,8 +1,12 @@
 from argparse import ArgumentParser
 
 import luigi
+import torch
 from pyspark.ml.classification import RandomForestClassifier
+from pyspark.sql import functions as F
 from xgboost.spark import SparkXGBClassifier
+
+from geolifeclef.utils import spark_resource
 
 from .logistic import BaseFitModel, FitLogisticModel
 from .utils import RsyncGCSFiles
@@ -19,10 +23,14 @@ class FitRandomForestModel(BaseFitModel):
 
 class FitXGBoostModel(BaseFitModel):
     device = luigi.Parameter(default="cpu")
+    num_workers = luigi.IntParameter(default=2)
 
     def _classifier(self, featuresCol: str, labelCol: str):
         return SparkXGBClassifier(
-            features_col=featuresCol, label_col=labelCol, device=self.device
+            features_col=featuresCol,
+            label_col=labelCol,
+            device=self.device,
+            num_workers=self.num_workers,
         )
 
 
@@ -36,31 +44,82 @@ class BenchmarkClassificationWorkflow(luigi.Task):
             dst_path=f"{self.local_root}/processed/metadata_clean/v1",
         )
 
-        for k in [3, 20, 100]:
+        for k in [3, 20, 100, 200]:
             yield [
                 # these runs are meant to validate that the pipeline works as expected before expensive runs
-                FitLogisticModel(
-                    k=k,
-                    shuffle_partitions=32,
-                    label="speciesSubsetId",
-                    input_path=f"{self.local_root}/processed/metadata_clean/v1",
-                    output_path=f"{self.local_root}/models/benchmark_classification/v2/model=logistic/k={k}",
+                *(
+                    [
+                        # non-linear scaling behavior for some reason, this
+                        # is terrible as a baseline because it literally takes forever
+                        FitLogisticModel(
+                            k=k,
+                            shuffle_partitions=32,
+                            label="speciesSubsetId",
+                            input_path=f"{self.local_root}/processed/metadata_clean/v1",
+                            output_path=f"{self.local_root}/models/benchmark_classification/v2/model=logistic/k={k}",
+                        ),
+                        # unfortunately this only supports up to 100 classes, but
+                        # otherwise the performance is great
+                        FitRandomForestModel(
+                            k=k,
+                            shuffle_partitions=32,
+                            label="speciesSubsetId",
+                            input_path=f"{self.local_root}/processed/metadata_clean/v1",
+                            output_path=f"{self.local_root}/models/benchmark_classification/v2/model=random_forest/k={k}",
+                        ),
+                    ]
+                    if k <= 100
+                    else []
                 ),
-                FitRandomForestModel(
-                    k=k,
-                    shuffle_partitions=32,
-                    label="speciesSubsetId",
-                    input_path=f"{self.local_root}/processed/metadata_clean/v1",
-                    output_path=f"{self.local_root}/models/benchmark_classification/v2/model=random_forest/k={k}",
-                ),
-                FitXGBoostModel(
-                    k=k,
-                    shuffle_partitions=32,
-                    label="speciesSubsetId",
-                    input_path=f"{self.local_root}/processed/metadata_clean/v1",
-                    output_path=f"{self.local_root}/models/benchmark_classification/v2/model=xgboost/k={k}",
-                ),
+                # multiple workers for xgboost because a single worker is deadfully slow
+                *[
+                    *[
+                        FitXGBoostModel(
+                            k=k,
+                            shuffle_partitions=32,
+                            num_workers=num_workers,
+                            label="speciesSubsetId",
+                            input_path=f"{self.local_root}/processed/metadata_clean/v1",
+                            output_path=f"{self.local_root}/models/benchmark_classification/v2/model=xgboost_n{num_workers}/k={k}",
+                        )
+                        for num_workers in [2, 8, 16]
+                    ],
+                    *(
+                        [
+                            FitXGBoostModel(
+                                k=k,
+                                shuffle_partitions=32,
+                                num_workers=num_workers,
+                                device="gpu",
+                                label="speciesSubsetId",
+                                input_path=f"{self.local_root}/processed/metadata_clean/v1",
+                                output_path=f"{self.local_root}/models/benchmark_classification/v2/model=xgboost_gpu_n{num_workers}/k={k}",
+                            )
+                            # we can only have one worker per gpu
+                            for num_workers in [1]
+                        ]
+                        if torch.cuda.is_available()
+                        else []
+                    ),
+                ],
             ]
+
+        # now print the results
+        with spark_resource() as spark:
+            df = (
+                spark.read.json(
+                    f"{self.local_root}/models/benchmark_classification/v2/*/*/perf"
+                )
+                .withColumn("file", F.input_file_name())
+                .select(
+                    F.regexp_extract("file", r"model=(\w+)", 1).alias("model"),
+                    F.regexp_extract("file", r"k=(\d+)", 1).cast("integer").alias("k"),
+                    F.round(F.col("avg_metrics")[0], 2).alias("f1_avg"),
+                    F.round(F.col("std_metrics")[0], 2).alias("f1_std"),
+                    F.round("train_time", 2).alias("train_time"),
+                )
+            ).orderBy("model", "k")
+            df.show(n=100)
 
 
 if __name__ == "__main__":

--- a/geolifeclef/workflows/benchmark_classification.py
+++ b/geolifeclef/workflows/benchmark_classification.py
@@ -1,0 +1,48 @@
+import luigi
+from .logistic import FitSubsetLogisticModel
+from .utils import RsyncGCSFiles
+from argparse import ArgumentParser
+
+
+class BenchmarkClassificationWorkflow(luigi.Task):
+    remote_root = luigi.Parameter(default="gs://dsgt-clef-geolifeclef-2024/data")
+    local_root = luigi.Parameter(default="/mnt/data/geolifeclef-2024/data")
+
+    def run(self):
+        yield RsyncGCSFiles(
+            src_path=f"{self.remote_root}/processed/metadata_clean/v1",
+            dst_path=f"{self.local_root}/processed/metadata_clean/v1",
+        )
+
+        yield [
+            # these runs are meant to validate that the pipeline works as expected before expensive runs
+            FitSubsetLogisticModel(
+                k=3,
+                max_iter=[5],
+                num_folds=2,
+                shuffle_partitions=8,
+                input_path=f"{self.local_root}/processed/metadata_clean/v1",
+                output_path=f"{self.local_root}/models/benchmark_classification/v1_test/logistic",
+            )
+        ]
+
+        # now fit this on a larger dataset to see if this works in a more realistic setting
+        yield [
+            FitSubsetLogisticModel(
+                shuffle_partitions=8,
+                input_path=f"{self.local_root}/processed/metadata_clean/v1",
+                output_path=f"{self.local_root}/models/benchmark_classification/v1/logistic",
+            )
+        ]
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("--scheduler-host", default="localhost")
+    args = parser.parse_args()
+
+    luigi.build(
+        [BenchmarkClassificationWorkflow()],
+        scheduler_host=args.scheduler_host,
+        workers=1,
+    )

--- a/geolifeclef/workflows/logistic.py
+++ b/geolifeclef/workflows/logistic.py
@@ -86,9 +86,6 @@ class BaseFitModel(luigi.Task):
     )
     k = luigi.IntParameter(default=None)
 
-    cores = luigi.IntParameter(default=4)
-    memory = luigi.Parameter(default="4g")
-
     num_folds = luigi.IntParameter(default=3)
     seed = luigi.IntParameter(default=42)
     shuffle_partitions = luigi.IntParameter(default=500)
@@ -168,8 +165,6 @@ class BaseFitModel(luigi.Task):
 
     def run(self):
         with spark_resource(
-            cores=self.cores,
-            memory=self.memory,
             **{
                 # increase shuffle partitions to avoid OOM
                 "spark.sql.shuffle.partitions": self.shuffle_partitions,
@@ -202,9 +197,9 @@ class BaseFitModel(luigi.Task):
                     }
                 ],
                 schema="""
-                    train_time double, 
-                    avg_metrics array<double>, 
-                    std_metrics array<double>, 
+                    train_time double,
+                    avg_metrics array<double>,
+                    std_metrics array<double>,
                     metric_name string
                 """,
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ scikit-learn
 torch
 torchvision
 transformers
+xgboost
 
 tqdm
 contexttimer


### PR DESCRIPTION
```
+--------------+---+------+------+----------+                                                                                  
|         model|  k|f1_avg|f1_std|train_time|                                                                                  
+--------------+---+------+------+----------+                                                                                  
|      logistic|  3|  0.95|  0.95|    141.19|                                                                                  
|      logistic| 20|  0.37|  0.37|    265.19|                                                                                  
|      logistic|100|   0.2|   0.2|   1304.83|                                                                                  
| random_forest|  3|  0.98|  0.98|     37.66|                                                                                  
| random_forest| 20|   0.5|   0.5|     52.38|                                                                                  
| random_forest|100|  0.28|  0.28|     53.26|                                                                                  
|xgboost_gpu_n1|  3|  0.91|  0.91|     41.27|                                                                                  
|xgboost_gpu_n1| 20|  0.61|  0.61|     66.73|                                                                                  
|xgboost_gpu_n1|100|  0.39|  0.39|    198.61|                                                                                  
|xgboost_gpu_n1|200|   0.1|   0.1|    304.32|                                                                                  
|    xgboost_n1|  3|  0.97|  0.97|     39.03|                                                                                  
|    xgboost_n1| 20|  0.61|  0.61|     48.66|                                                                                  
|    xgboost_n1|100|  0.39|  0.39|    155.45|                                                                                  
|   xgboost_n16|  3|  0.95|  0.95|     46.32|                                                                                  
|   xgboost_n16| 20|  0.61|  0.61|     71.95|                                                                                  
|   xgboost_n16|100|  0.39|  0.39|    154.23|                                                                                  
|   xgboost_n16|200|  0.13|  0.13|     204.2|                                                                                  
|    xgboost_n2|  3|  0.95|  0.95|     40.59|                                                                                  
|    xgboost_n2| 20|  0.61|  0.61|     49.56|                                                                                  
|    xgboost_n2|100|  0.39|  0.39|    123.49|                                                                                  
|    xgboost_n2|200|  0.13|  0.13|    359.91|                                                                                  
|    xgboost_n8|  3|  0.95|  0.95|     42.67|                                                                                  
|    xgboost_n8| 20|  0.61|  0.61|     59.95|                                                                                  
|    xgboost_n8|100|  0.39|  0.39|    131.76|                                                                                  
|    xgboost_n8|200|  0.18|  0.18|    225.45|                                                                                  
+--------------+---+------+------+----------+   
```